### PR TITLE
fix exports map, tsup config and docs

### DIFF
--- a/.changeset/loose-radios-join.md
+++ b/.changeset/loose-radios-join.md
@@ -1,0 +1,6 @@
+---
+"vite-plugin-transform-lucide-imports": patch
+---
+
+fix: correct exports map ordering
+  

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ import { defineConfig } from "vite";
 import transformLucideImports from "vite-plugin-transform-lucide-imports";
 
 export default defineConfig({
-	plugins: [transformLucideImports()],
+	plugins: [/* other framework plugins */, transformLucideImports()],
 });
 ```
 
@@ -60,13 +60,13 @@ For frameworks that transpile to a valid JS / JSX syntax you can just pass your 
 
 ```ts
 import { defineConfig } from "vite";
-import { sveltekit } from "@sveltejs/kit/vite";
+import vue from "@vitejs/plugin-vue";
 import transformLucideImports, { SUPPORTED_EXTENSIONS } from "vite-plugin-transform-lucide-imports";
 
 export default defineConfig({
 	// the plugin MUST be added after the plugin doing the transpilation
 	// you may also want to spread the supported extensions to continue to support other extensions
-	plugins: [sveltekit(), transformLucideImports({ extensions: [...SUPPORTED_EXTENSIONS, ".svelte"] })],
+	plugins: [vue(), transformLucideImports({ extensions: [...SUPPORTED_EXTENSIONS, ".vue"] })],
 });
 ```
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -15,7 +15,7 @@ import { defineConfig } from "vite";
 import transformLucideImports from "vite-plugin-transform-lucide-imports";
 
 export default defineConfig({
-	plugins: [transformLucideImports()],
+	plugins: [/* other framework plugins */, transformLucideImports()],
 });
 ```
 
@@ -60,13 +60,13 @@ For frameworks that transpile to a valid JS / JSX syntax you can just pass your 
 
 ```ts
 import { defineConfig } from "vite";
-import { sveltekit } from "@sveltejs/kit/vite";
+import vue from "@vitejs/plugin-vue";
 import transformLucideImports, { SUPPORTED_EXTENSIONS } from "vite-plugin-transform-lucide-imports";
 
 export default defineConfig({
 	// the plugin MUST be added after the plugin doing the transpilation
 	// you may also want to spread the supported extensions to continue to support other extensions
-	plugins: [sveltekit(), transformLucideImports({ extensions: [...SUPPORTED_EXTENSIONS, ".svelte"] })],
+	plugins: [vue(), transformLucideImports({ extensions: [...SUPPORTED_EXTENSIONS, ".vue"] })],
 });
 ```
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -7,8 +7,8 @@
 	"module": "dist/index.js",
 	"exports": {
 		".": {
-			"import": "./dist/index.js",
-			"types": "./dist/index.d.ts"
+			"types": "./dist/index.d.ts",
+			"default": "./dist/index.js"
 		}
 	},
 	"files": [

--- a/packages/core/src/plugin.ts
+++ b/packages/core/src/plugin.ts
@@ -15,12 +15,14 @@ export type Options = {
 	 * 	plugins: [
 	 * 		transformLucideImports(
 	 * 			{
-	 * 				extensions: [...SUPPORTED_EXTENSIONS, ".svelte"] 
+	 * 				extensions: [...SUPPORTED_EXTENSIONS, ".vue"] 
 	 * 			}
 	 * 		),
 	 * 	],
 	 * });
 	 * ```
+	 * 
+	 * @default [ ".ts", ".tsx", ".js", ".jsx", ".mjs", ".svelte" ]
 	 */
 	extensions?: string[];
 };

--- a/packages/core/tsup.config.ts
+++ b/packages/core/tsup.config.ts
@@ -3,7 +3,5 @@ import { defineConfig } from "tsup";
 export default defineConfig({
 	entry: ["src/index.ts"],
 	dts: true,
-	external: ["vite"],
-	treeshake: true,
 	format: ["esm"],
 });


### PR DESCRIPTION
- the package should be using the `default` export condition (since the package's type is using `module`, `import` isn't necessary) and `types` should be declared above that for proper types detection

- removed some unnecessary tsup config stuff. `vite` is already externalized since it's listed under peer-deps in the `package.json`

- tweaked docs as to not confuse svelte users. atm the examples in the docs makes it appear that they _need_ to add the `.svelte` extension to the `extensions` array, despite it already existing as the default