### PR TITLE
add `onwarn`

### DIFF
--- a/.changeset/dark-mirrors-clap.md
+++ b/.changeset/dark-mirrors-clap.md
@@ -1,0 +1,6 @@
+---
+"vite-plugin-transform-lucide-imports": minor
+---
+
+feat: add `onwarn` option
+  

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,5 +1,5 @@
 export { normalizeName } from './utils';
 
-export { transform } from './transform';
+export { transform, type Warning } from './transform';
 
 export { plugin as default, SUPPORTED_EXTENSIONS, type Options } from './plugin';

--- a/packages/core/src/plugin.ts
+++ b/packages/core/src/plugin.ts
@@ -28,7 +28,7 @@ export type Options = {
 	/**
 	 * Custom warning handler. If not provided, the plugin will use Vite's built-in warning system.
 	 */
-	onwarn?: (warning: Warning, defaultHandler: (msg: string) => void) => void;
+	onwarn?: (warning: Warning, defaultHandler: (message: string) => void) => void;
 };
 
 export const plugin = (options?: Options): Plugin => {

--- a/packages/core/src/plugin.ts
+++ b/packages/core/src/plugin.ts
@@ -1,5 +1,5 @@
 import type { Plugin } from "vite";
-import { transform as coreTransform } from "./transform";
+import { transform as coreTransform, Warning } from "./transform";
 
 export const SUPPORTED_EXTENSIONS = [".ts", ".tsx", ".js", ".jsx", ".mjs", ".svelte"];
 
@@ -15,20 +15,20 @@ export type Options = {
 	 * 	plugins: [
 	 * 		transformLucideImports(
 	 * 			{
-	 * 				extensions: [...SUPPORTED_EXTENSIONS, ".vue"] 
+	 * 				extensions: [...SUPPORTED_EXTENSIONS, ".vue"]
 	 * 			}
 	 * 		),
 	 * 	],
 	 * });
 	 * ```
-	 * 
+	 *
 	 * @default [ ".ts", ".tsx", ".js", ".jsx", ".mjs", ".svelte" ]
 	 */
 	extensions?: string[];
 	/**
 	 * Custom warning handler. If not provided, the plugin will use Vite's built-in warning system.
 	 */
-	onwarn?: (message: string, handler: (message: string) => void) => void;
+	onwarn?: (warning: Warning, defaultHandler: (msg: string) => void) => void;
 };
 
 export const plugin = (options?: Options): Plugin => {
@@ -40,14 +40,13 @@ export const plugin = (options?: Options): Plugin => {
 
 			return {
 				code: coreTransform(code, {
-					warn: (message: string) => {
+					warn: (warning: Warning) => {
 						if (!options?.onwarn) {
-							this.warn(message);
+							this.warn(warning.message);
+						} else {
+							options.onwarn(warning, (msg) => this.warn(msg));
 						}
-						else {
-							options.onwarn(message, (msg) => this.warn(msg));
-						}
-					}
+					},
 				}),
 			};
 		},

--- a/packages/core/src/plugin.ts
+++ b/packages/core/src/plugin.ts
@@ -25,6 +25,10 @@ export type Options = {
 	 * @default [ ".ts", ".tsx", ".js", ".jsx", ".mjs", ".svelte" ]
 	 */
 	extensions?: string[];
+	/**
+	 * Custom warning handler. If not provided, the plugin will use Vite's built-in warning system.
+	 */
+	onwarn?: (message: string, handler: (message: string) => void) => void;
 };
 
 export const plugin = (options?: Options): Plugin => {
@@ -36,7 +40,14 @@ export const plugin = (options?: Options): Plugin => {
 
 			return {
 				code: coreTransform(code, {
-					warn: (message: string) => this.warn(message),
+					warn: (message: string) => {
+						if (!options?.onwarn) {
+							this.warn(message);
+						}
+						else {
+							options.onwarn(message, this.warn);
+						}
+					}
 				}),
 			};
 		},

--- a/packages/core/src/plugin.ts
+++ b/packages/core/src/plugin.ts
@@ -45,7 +45,7 @@ export const plugin = (options?: Options): Plugin => {
 							this.warn(message);
 						}
 						else {
-							options.onwarn(message, this.warn);
+							options.onwarn(message, (msg) => this.warn(msg));
 						}
 					}
 				}),


### PR DESCRIPTION
Closes #13

Adds a `onwarn` handler similar to Svelte's `onwarn` where a handler is passed to replicate default behaviour.

Usage:

```ts
onwarn(message, handler) {
    if (message.contains('Skipping optimization of') {
        return 
    }
    handler(message);
}
```

So you can disable certain warnings if you feel like it (or even provide your own logger)